### PR TITLE
Fix CI by using fixed flutter version 3.10.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: subosito/flutter-action@v1
         with:
-          channel: "stable"
+          flutter-version: '3.10.6'
 
       - name: Get dependencies
         run: flutter pub get
@@ -49,7 +49,7 @@ jobs:
 
       - uses: subosito/flutter-action@v1
         with:
-          channel: "stable"
+          flutter-version: '3.10.6'
 
       - name: Generate debug keystore (Pull Request)
         if: github.event_name == 'pull_request'
@@ -93,7 +93,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          channel: "stable"
+          flutter-version: '3.10.6'
 
       - run: flutter build ios --no-codesign --release --target lib/main_prod.dart --flavor prod
 
@@ -106,7 +106,7 @@ jobs:
 
       - uses: subosito/flutter-action@v1
         with:
-          channel: "stable"
+          flutter-version: '3.10.6'
 
       - name: Get additional dependencies
         run: |
@@ -126,7 +126,7 @@ jobs:
 
       - uses: subosito/flutter-action@v1
         with:
-          channel: "stable"
+          flutter-version: '3.10.6'
 
       - name: Build
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: subosito/flutter-action@v1
         with:
-          channel: "stable"
+          flutter-version: '3.10.6'
 
       - name: Get dependencies
         run: flutter pub get
@@ -86,7 +86,7 @@ jobs:
 
       - uses: subosito/flutter-action@v1
         with:
-          channel: "stable"
+          flutter-version: '3.10.6'
 
       - name: Get additional dependencies
         run: |
@@ -116,7 +116,7 @@ jobs:
 
       - uses: subosito/flutter-action@v1
         with:
-          channel: "stable"
+          flutter-version: '3.10.6'
 
       - name: Build
         run: |


### PR DESCRIPTION
Building the pull requests by the CI stopped working some time ago. Presumably, the specified flutter channel "stable" got updated and is now incompatible which lets every build fail. Pinning the flutter version to 3.10.6 for the CI fixes that. Note that the version was chosen by best guess that worked at least somewhat locally. (I have yet to get a build finished locally.) It might not be the version that was used "originally".